### PR TITLE
feat: add modern dark theme

### DIFF
--- a/src/components/Footer/index.module.scss
+++ b/src/components/Footer/index.module.scss
@@ -5,7 +5,8 @@ footer {
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
-    background-color: #E6E6E6;
+    background-color: $grayDark;
+    color: $grayXLight;
     
     .footerTop ,
     .footerBottom {
@@ -28,7 +29,7 @@ footer {
 
         .copyright,
         .link {
-            color: #707070;
+            color: $gray;
         }
         
         .link {

--- a/src/components/Header/index.module.scss
+++ b/src/components/Header/index.module.scss
@@ -1,3 +1,5 @@
+@import "/src/styles";
+
 header {
     min-height: 3.75rem;
     max-width: 100rem;
@@ -7,6 +9,8 @@ header {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    background-color: $grayDark;
+    color: $grayXLight;
 
     .logo {
         display: flex;
@@ -21,6 +25,7 @@ header {
     .headerLinks {
         a {
             margin: 0 .5rem;
+            color: $grayXLight;
 
             &:last-of-type {
                 margin-right: 0;
@@ -29,7 +34,7 @@ header {
     }
 
     .signupButtonWrapper {
-        border-left: 1px solid;
+        border-left: 1px solid $grayLight;
         padding-left: 1.5rem;
         margin-left: 1.5rem;
     }

--- a/src/routes/Main/ApiDetail/index.module.scss
+++ b/src/routes/Main/ApiDetail/index.module.scss
@@ -16,15 +16,16 @@
 }
 
 .container {
-	box-sizing: border-box;
-	position: relative;
-	max-width: 38rem;
-	width: 90%;
-	height: 100%;
-	margin-left: auto;
-	padding: 2rem;
-	background: white;
-	box-shadow: 0 0 2rem rgba(0, 0, 0, .25);
+        box-sizing: border-box;
+        position: relative;
+        max-width: 38rem;
+        width: 90%;
+        height: 100%;
+        margin-left: auto;
+        padding: 2rem;
+        background: $surface;
+        box-shadow: 0 0 2rem rgba(0, 0, 0, .6);
+        color: $grayXLight;
 	overflow-y: auto;
 
 	p {
@@ -90,10 +91,10 @@
 				text-decoration: underline;
 			}
 
-			&:disabled {
-				color: black;
-				pointer-events: none;
-			}
+                        &:disabled {
+                                color: $grayLight;
+                                pointer-events: none;
+                        }
 
 			svg {
 				margin-right: .375rem;

--- a/src/routes/Main/ApisList/ApisCards/index.module.scss
+++ b/src/routes/Main/ApisList/ApisCards/index.module.scss
@@ -8,12 +8,14 @@
 }
 
 .apiCard {
-	display: flex;
-	flex-direction: column;
-	padding: 1rem;
-	border-radius: 0.5rem;
-	box-shadow: 0 0 0.125rem 0 rgba(0, 0, 0, 0.24), 0 0.125rem 0.25rem 0 rgba(0, 0, 0, 0.28);
-	cursor: pointer;
+        display: flex;
+        flex-direction: column;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        background-color: $surface;
+        box-shadow: 0 0 0.25rem rgba(0, 0, 0, 0.5);
+        cursor: pointer;
+        color: $grayXLight;
 
 	.content {
 		height: 100%;
@@ -25,37 +27,38 @@
 			font-weight: 600;
 		}
 
-		.tags {
-			display: flex;
-			gap: 0.75rem;
-			margin-bottom: 0.75rem;
+                .tags {
+                        display: flex;
+                        gap: 0.75rem;
+                        margin-bottom: 0.75rem;
 
-			span {
-				color: $gray;
-				font-size: 0.75rem;
-				font-style: normal;
-				font-weight: 700;
-				line-height: 1rem;
-				text-transform: uppercase;
+                        span {
+                                color: $gray;
+                                font-size: 0.75rem;
+                                font-style: normal;
+                                font-weight: 700;
+                                line-height: 1rem;
+                                text-transform: uppercase;
 
-				&:not(:last-of-type) {
-					padding-right: 0.75rem;
-					border-right: 1px solid $gray;
-				}
-			}
-		}
+                                &:not(:last-of-type) {
+                                        padding-right: 0.75rem;
+                                        border-right: 1px solid $gray;
+                                }
+                        }
+                }
 
-		.description {
-			font-size: 0.875rem;
-			font-weight: 400;
-			line-height: 1.25rem;
-			/* 142.857% */
-		}
-	}
+                .description {
+                        font-size: 0.875rem;
+                        font-weight: 400;
+                        line-height: 1.25rem;
+                        /* 142.857% */
+                        color: $gray;
+                }
+        }
 
-	.menuButton {
-		align-self: flex-end;
-	}
+        .menuButton {
+                align-self: flex-end;
+        }
 }
 
 .copiedTooltip {

--- a/src/routes/Main/ApisList/ApisTable/index.module.scss
+++ b/src/routes/Main/ApisList/ApisTable/index.module.scss
@@ -1,9 +1,11 @@
 @import "/src/styles/index";
 
 .container {
-	margin-top: 1.5rem;
-	border-radius: 0.375rem;
-	box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 1px 2px 0 rgba(0, 0, 0, 0.14);
+        margin-top: 1.5rem;
+        border-radius: 0.375rem;
+        box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 1px 2px 0 rgba(0, 0, 0, 0.14);
+        background-color: $surface;
+        color: $grayXLight;
 
 	.link {
 		color: $blue;

--- a/src/routes/Main/ApisList/index.module.scss
+++ b/src/routes/Main/ApisList/index.module.scss
@@ -43,18 +43,20 @@
 }
 
 .filtersActive {
-	display: flex;
-	gap: 1rem;
-	margin: 1rem 0 1.75rem;
-	flex-wrap: wrap;
+        display: flex;
+        gap: 1rem;
+        margin: 1rem 0 1.75rem;
+        flex-wrap: wrap;
 
-	.filterTag {
-		padding: 0.3rem 0.75rem;
-		border: solid 1px $grayLight;
-		border-radius: 0.25rem;
-		font-size: 0.875rem;
-		line-height: 1.25rem;
-		/* 142.857% */
+        .filterTag {
+                padding: 0.3rem 0.75rem;
+                border: solid 1px $grayLight;
+                background: $surface;
+                color: $grayXLight;
+                border-radius: 0.25rem;
+                font-size: 0.875rem;
+                line-height: 1.25rem;
+                /* 142.857% */
 
 		b {
 			font-weight: 600;
@@ -67,11 +69,12 @@
 }
 
 .filtersClearAll {
-	font-size: 0.875rem;
-	font-weight: 600;
-	line-height: 1.25rem;
-	/* 142.857% */
-	text-decoration-line: underline;
+        font-size: 0.875rem;
+        font-weight: 600;
+        line-height: 1.25rem;
+        /* 142.857% */
+        text-decoration-line: underline;
+        color: $blue;
 }
 
 .emptyState {

--- a/src/routes/Main/Heading/index.module.scss
+++ b/src/routes/Main/Heading/index.module.scss
@@ -1,10 +1,10 @@
 @import "/src/styles/index";
 
 .heading {
-	padding: 3.125rem 3.125rem 4rem;
-	background: linear-gradient(45deg, hsla(204, 65%, 71%, 1) 0%, hsla(273, 34%, 75%, 1) 43%, hsla(358, 43%, 75%, 1) 57%, hsla(43, 96%, 63%, 1) 100%);
-	color: white;
-	text-align: center;
+        padding: 3.125rem 3.125rem 4rem;
+        background: linear-gradient(145deg, #1f2937 0%, #111827 100%);
+        color: $grayXLight;
+        text-align: center;
 
 	h1 {
 		margin: 0 0 1rem;
@@ -29,9 +29,9 @@
 		line-height: 1.25rem;
 		/* 142.857% */
 
-		a {
-			color: white;
-			text-decoration: none;
+                a {
+                        color: $blue;
+                        text-decoration: none;
 
 			&:hover {
 				text-decoration: underline;
@@ -54,14 +54,14 @@
 		width: 100%;
 	}
 
-	.popup {
-		box-sizing: border-box;
-		position: absolute;
-		width: 100%;
-		background: white;
-		color: black;
-		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.50);
-		z-index: 1;
+        .popup {
+                box-sizing: border-box;
+                position: absolute;
+                width: 100%;
+                background: $surface;
+                color: $grayXLight;
+                box-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+                z-index: 1;
 
 		.header {
 			display: flex;
@@ -103,25 +103,25 @@
 				font-size: 0.875rem;
 			}
 
-			&:hover {
-				background: $grayXLight;
+                        &:hover {
+                                background: $grayLight;
 
-				.recordDelete {
-					display: block;
-				}
-			}
+                                .recordDelete {
+                                        display: block;
+                                }
+                        }
 
-			.recordDelete {
-				display: none;
-				width: 2rem;
-				height: 2rem;
-				flex-shrink: 0;
-				background: #E1DFDD;
+                        .recordDelete {
+                                display: none;
+                                width: 2rem;
+                                height: 2rem;
+                                flex-shrink: 0;
+                                background: $grayLight;
 
-				&:hover {
-					background: $grayLight;
-				}
-			}
+                                &:hover {
+                                        background: $gray;
+                                }
+                        }
 			
 			.apiName,
 			.apiMeta {

--- a/src/styles/colors.module.scss
+++ b/src/styles/colors.module.scss
@@ -1,13 +1,16 @@
-$blue: #115EA3;
-$blueLight: #0F6CBD;
-$blueButton: #6387E3;
-$gray: #616161;
-$grayDark: #242424;
-$grayLight: #D1D1D1;
-$grayXLight: #F3F2F1;
+$blue: #3ecf8e; // accent color
+$blueLight: #4ee9a3;
+$blueButton: #3ecf8e;
+$gray: #9ca3af;
+$grayDark: #1a1d1f; // page background
+$grayLight: #4b5563;
+$grayXLight: #f3f4f6;
+$surface: #262a33; // card and surface background
 
 :export {
-	// add color here, that you need to use in JSX
-	blueLight: $blueLight;
-	blueButton: $blueButton;
+        // add colors here that you need to use in JSX
+        blueLight: $blueLight;
+        blueButton: $blueButton;
+        surface: $surface;
+        textColor: $grayXLight;
 }

--- a/src/styles/layouts.module.scss
+++ b/src/styles/layouts.module.scss
@@ -9,6 +9,8 @@ body,
 body {
     margin: 0;
     position: relative;
+    background-color: $grayDark;
+    color: $grayXLight;
 }
 
 h1, h2, h3, h4, h5, h6, p {


### PR DESCRIPTION
## Summary
- introduce dark color palette and surface styling
- restyle header, footer, cards, and filters for dark mode
- tweak landing heading and detail modal for modern look

## Testing
- `npx eslint . --ext .ts,.tsx --ignore-path ./.gitignore`
- `npx prettier "src/**/*.scss" --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4ca54bde8832cb71c4429d88d3d75